### PR TITLE
Included the manifest file to find header files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include src/C/*.h

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,7 @@ extension_mod = Extension(name = "catch22_C",
     include_dirs = [sourceDir])  # Header files are here
 
 setup(
-    include_dirs = [sourceDir],
     packages = find_packages(where = "src",
-            include=["pycatch22"]),
-    ext_modules = [extension_mod],
-    include_package_data = True
+                             include=["pycatch22"]),
+    ext_modules = [extension_mod]
 )


### PR DESCRIPTION
You need to include a `MANIFEST.in` file to let `setup.py` know where the header files are.

With this, you can now create the source distribution:
```
python setup.py sdist
```
And then re-upload using twine.