### PR TITLE
Fix for the issue #5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ extra_compile_args += ["-std=c99"]
 extension_mod = Extension(name = "catch22_C",
     sources = sourceFileList,
     include_dirs = [sourceDir],
-    extra_compile_args=extra_compile_args,)  # Header files are here
+    extra_compile_args = extra_compile_args)  # Header files are here
 
 setup(
     packages = find_packages(where = "src",

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup, Extension, find_packages
+import sysconfig
 import os
 
 sourceDir = os.path.join("src", "C");
@@ -7,10 +8,14 @@ sourceFileList = [os.path.join(sourceDir, file) for file in os.listdir(sourceDir
     ".c") and not 'main' in file]
     # and not (file == "sampen.c" or file == "run_features.c")]
 
+extra_compile_args = sysconfig.get_config_var('CFLAGS').split()
+extra_compile_args += ["-std=c99"]
+
 # The c++ extension module:
 extension_mod = Extension(name = "catch22_C",
     sources = sourceFileList,
-    include_dirs = [sourceDir])  # Header files are here
+    include_dirs = [sourceDir],
+    extra_compile_args=extra_compile_args,)  # Header files are here
 
 setup(
     packages = find_packages(where = "src",


### PR DESCRIPTION
Hello, I hope you are well.
Error number 5 occurs because some systems do not use the C99 language by default (which is the C standard published in 1999). This is necessary for the counter statements to be made inside the "for" loop, for example.
To address this, the default "c99" was explicitly added to "CFLAGS". I believe this fixes the error.
Feel free to edit the solution or propose a different one.