### PR TITLE
Fix for Installing on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,19 @@ sourceFileList = [os.path.join(sourceDir, file) for file in os.listdir(sourceDir
     ".c") and not 'main' in file]
     # and not (file == "sampen.c" or file == "run_features.c")]
 
+cflags = sysconfig.get_config_var('CFLAGS')
+if cflags is not None:
+    extra_compile_args = cflags.split()
+else: # Windows system
+    extra_compile_args = []
+
+extra_compile_args += ["-std=c99"]
+
 # The c++ extension module:
 extension_mod = Extension(name = "catch22_C",
     sources = sourceFileList,
     include_dirs = [sourceDir],
-    extra_compile_args = ["-std=c99"])  # Header files are here
+    extra_compile_args = extra_compile_args)  # Header files are here
 
 setup(
     packages = find_packages(where = "src",

--- a/setup.py
+++ b/setup.py
@@ -8,17 +8,11 @@ sourceFileList = [os.path.join(sourceDir, file) for file in os.listdir(sourceDir
     ".c") and not 'main' in file]
     # and not (file == "sampen.c" or file == "run_features.c")]
 
-cflags = sysconfig.get_config_var('CFLAGS')
-if cflags is None: # Windows system
-    extra_compile_args = ["-std=c99"]
-else: # Unix system
-    extra_compile_args = cflags.split() + ["-std=c99"]
-
 # The c++ extension module:
 extension_mod = Extension(name = "catch22_C",
     sources = sourceFileList,
     include_dirs = [sourceDir],
-    extra_compile_args = extra_compile_args)  # Header files are here
+    extra_compile_args = ["-std=c99"])  # Header files are here
 
 setup(
     packages = find_packages(where = "src",

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,11 @@ sourceFileList = [os.path.join(sourceDir, file) for file in os.listdir(sourceDir
     ".c") and not 'main' in file]
     # and not (file == "sampen.c" or file == "run_features.c")]
 
-extra_compile_args = sysconfig.get_config_var('CFLAGS').split()
-extra_compile_args += ["-std=c99"]
+cflags = sysconfig.get_config_var('CFLAGS')
+if cflags is None: # Windows system
+    extra_compile_args = ["-std=c99"]
+else: # Unix system
+    extra_compile_args = cflags.split() + ["-std=c99"]
 
 # The c++ extension module:
 extension_mod = Extension(name = "catch22_C",


### PR DESCRIPTION
This is to fix #20 - Windows systems don't have a config variable called CFLAGS so the previous fix for #5 would throw errors.

I've added a fix that checks if this situation occurs, and if so installs the package with just the -std=c99 flag. For the people who didn't have installation issues before it should still install the same way.