### PR TITLE
Update CO_f1ecac and CO_FirstMin_ac names

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Thanks to [@jmoo2880](https://github.com/jmoo2880) for putting together a [demon
 
 ### Usage notes
 
-- When presenting results using _catch22_, you must identify the version used to allow clear reproduction of your results. For example, `CO_f1ecac` was altered from an integer-valued output to a linearly interpolated real-valued output from v0.3.
+- When presenting results using _catch22_, you must identify the version used to allow clear reproduction of your results. For example, `first1e_acf_tau` was altered from an integer-valued output to a linearly interpolated real-valued output from v0.3.
 - __Important Note:__ _catch22_ features only evaluate _dynamical_ properties of time series and do not respond to basic differences in the location (e.g., mean) or spread (e.g., variance).
   - From _catch22_ v0.3, If the location and spread of the raw time-series distribution may be important for your application, we suggest applying the function argument `catch24 = True` to your call to the _catch22_ function in the language of your choice.
   This will result in 24 features being calculated: the _catch22_ features in addition to mean and standard deviation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pycatch22"
-version = "0.4.5"
+version = "0.4.6"
 authors = [
     {name = "Carl H Lubba"},
     {email = "carl.lubba@gmx.de"},

--- a/src/pycatch22/catch22.py
+++ b/src/pycatch22/catch22.py
@@ -18,8 +18,8 @@ def catch22_all(data, catch24=False, short_names=False):
     features = [
         'DN_HistogramMode_5',
         'DN_HistogramMode_10',
-        'CO_f1ecac',
-        'CO_FirstMin_ac',
+        'first1e_acf_tau',
+        'firstMin_acf',
         'CO_HistogramAMI_even_2_5',
         'CO_trev_1_num',
         'MD_hrv_classic_pnn40',

--- a/src/pycatch22/catch22.py
+++ b/src/pycatch22/catch22.py
@@ -14,7 +14,8 @@ def catch22_all(data, catch24=False, short_names=False):
         If True, also include the short names of the features in the output.
 
     '''
-   
+
+    # map the old function names to the new long feature names
     name_mapping = {
         'CO_f1ecac' : 'first1e_acf_tau',
         'CO_FirstMin_ac' : 'firstMin_acf'
@@ -83,7 +84,7 @@ def catch22_all(data, catch24=False, short_names=False):
         featureOut.append(featureFun(data))
 
     features = [name_mapping.get(s, s) for s in features]
-    
+
     if short_names:
         return {'names': features, 'short_names': features_short, 'values': featureOut}
     else:

--- a/src/pycatch22/catch22.py
+++ b/src/pycatch22/catch22.py
@@ -14,12 +14,17 @@ def catch22_all(data, catch24=False, short_names=False):
         If True, also include the short names of the features in the output.
 
     '''
+   
+    name_mapping = {
+        'CO_f1ecac' : 'first1e_acf_tau',
+        'CO_FirstMin_ac' : 'firstMin_acf'
+    }
 
     features = [
         'DN_HistogramMode_5',
         'DN_HistogramMode_10',
-        'first1e_acf_tau',
-        'firstMin_acf',
+        'CO_f1ecac',
+        'CO_FirstMin_ac',
         'CO_HistogramAMI_even_2_5',
         'CO_trev_1_num',
         'MD_hrv_classic_pnn40',
@@ -77,6 +82,8 @@ def catch22_all(data, catch24=False, short_names=False):
         featureFun = getattr(catch22_C, f)
         featureOut.append(featureFun(data))
 
+    features = [name_mapping.get(s, s) for s in features]
+    
     if short_names:
         return {'names': features, 'short_names': features_short, 'values': featureOut}
     else:

--- a/tests/benchmarks/expected_outputs/test2_output.txt
+++ b/tests/benchmarks/expected_outputs/test2_output.txt
@@ -1,7 +1,7 @@
 DN_HistogramMode_5, -0.6147991148452683
 DN_HistogramMode_10, -0.7822544655522088
-CO_f1ecac, 32.502605476936466
-CO_FirstMin_ac, 77
+first1e_acf_tau, 32.502605476936466
+firstMin_acf, 77
 CO_HistogramAMI_even_2_5, 1.0063890779937608
 CO_trev_1_num, 1.782472611547055e-05
 MD_hrv_classic_pnn40, 0.31970260223048325

--- a/tests/benchmarks/expected_outputs/testInfMinus_output.txt
+++ b/tests/benchmarks/expected_outputs/testInfMinus_output.txt
@@ -1,7 +1,7 @@
 DN_HistogramMode_5, nan
 DN_HistogramMode_10, nan
-CO_f1ecac, 0.0
-CO_FirstMin_ac, 0
+first1e_acf_tau, 0.0
+firstMin_acf, 0
 CO_HistogramAMI_even_2_5, nan
 CO_trev_1_num, nan
 MD_hrv_classic_pnn40, nan

--- a/tests/benchmarks/expected_outputs/testInf_output.txt
+++ b/tests/benchmarks/expected_outputs/testInf_output.txt
@@ -1,7 +1,7 @@
 DN_HistogramMode_5, nan
 DN_HistogramMode_10, nan
-CO_f1ecac, 0.0
-CO_FirstMin_ac, 0
+first1e_acf_tau, 0.0
+firstMin_acf, 0
 CO_HistogramAMI_even_2_5, nan
 CO_trev_1_num, nan
 MD_hrv_classic_pnn40, nan

--- a/tests/benchmarks/expected_outputs/testNaN_output.txt
+++ b/tests/benchmarks/expected_outputs/testNaN_output.txt
@@ -1,7 +1,7 @@
 DN_HistogramMode_5, nan
 DN_HistogramMode_10, nan
-CO_f1ecac, 0.0
-CO_FirstMin_ac, 0
+first1e_acf_tau, 0.0
+firstMin_acf, 0
 CO_HistogramAMI_even_2_5, nan
 CO_trev_1_num, nan
 MD_hrv_classic_pnn40, nan

--- a/tests/benchmarks/expected_outputs/testShort_output.txt
+++ b/tests/benchmarks/expected_outputs/testShort_output.txt
@@ -1,7 +1,7 @@
 DN_HistogramMode_5, 0.022699494958050126
 DN_HistogramMode_10, 0.022699494958050237
-CO_f1ecac, 2.675241846131576
-CO_FirstMin_ac, 8
+first1e_acf_tau, 2.675241846131576
+firstMin_acf, 8
 CO_HistogramAMI_even_2_5, 1.366158847569202
 CO_trev_1_num, 0.019643781964449922
 MD_hrv_classic_pnn40, 1.0

--- a/tests/benchmarks/expected_outputs/testSinusoid_output.txt
+++ b/tests/benchmarks/expected_outputs/testSinusoid_output.txt
@@ -1,7 +1,7 @@
 DN_HistogramMode_5, 1.272928076609852
 DN_HistogramMode_10, -1.1275857573774708
-CO_f1ecac, 119.7407960033787
-CO_FirstMin_ac, 2
+first1e_acf_tau, 119.7407960033787
+firstMin_acf, 2
 CO_HistogramAMI_even_2_5, 1.0794999556793812
 CO_trev_1_num, -0.00017509308632170917
 MD_hrv_classic_pnn40, 0.822

--- a/tests/benchmarks/expected_outputs/test_output.txt
+++ b/tests/benchmarks/expected_outputs/test_output.txt
@@ -1,7 +1,7 @@
 DN_HistogramMode_5, -0.6147991148452683
 DN_HistogramMode_10, -0.7822544655522088
-CO_f1ecac, 32.502605476936466
-CO_FirstMin_ac, 77
+first1e_acf_tau, 32.502605476936466
+firstMin_acf, 77
 CO_HistogramAMI_even_2_5, 1.0063890779937608
 CO_trev_1_num, 1.782472611547055e-05
 MD_hrv_classic_pnn40, 0.31970260223048325


### PR DESCRIPTION
This PR updates the older `CO_f1ecac` and `CO_FirstMin_ac` feature names to the newer `first1e_acf_tau` and `firstMin_acf` respectively. These changes have also been reflected in the unit tests. 